### PR TITLE
[FINAL] Fixing the Representative's title

### DIFF
--- a/app/views/shared/representativeForm.hbs
+++ b/app/views/shared/representativeForm.hbs
@@ -3,7 +3,7 @@
       <div class="text-center">
         <div class="congress-intro">
           <h5>YOUR CONGRESSPERSON IS</h5>
-          <h3><span id="officialTitle">{{title}} {{firstName}} {{lastName}} ({{party}})</span></h3>
+          <h3><span id="officialTitle">{{title}} {{first_name}} {{last_name}} ({{party}})</span></h3>
           <img
             id="rep-img"
             src="https://theunitedstates.io/images/congress/450x550/{{bioguide_id}}.jpg"
@@ -73,5 +73,3 @@
         <p>&copy; 2016 HelloGov</p>
       </footer>
     </div> <!-- /container -->
-
-


### PR DESCRIPTION
This is a tiny fix, so I figured I'd just take care of it.  ✅  I think the rep's title broke in the last refactor.  I changed the `camelCase` back to `lower_case_snake_case` for the key names here.  🔑   I don't care which style we go with in the long-term (as long as we stick entirely with one or the other), but this should fix it for now.  🐫 🐍 👍 