### PR TITLE
Fix buttons on Campaign Success page

### DIFF
--- a/app/views/campaignSuccess.hbs
+++ b/app/views/campaignSuccess.hbs
@@ -19,8 +19,8 @@
     <!-- TODO: This should give feedback so user knows link was copied, ideally like in the mockup -->
     <button class="cta-button btn-yellow" ngclipboard data-clipboard-text="https://www.hellogov.org/{[{shortid}]}" /><h3>Copy URL</h3></button>
     <!-- TODO: When we have actual preview page, use that URL instead -->
-    <div class="cta-button btn-blue"><a href="/{[{shortid}]}"><h3>Preview URL</h3></a></div>
-    <div class="cta-button btn-blue"><a href="/campaigns"><h3>Go to campaigns</h3></a></div>
+    <a href="/{[{shortid}]}"><div class="cta-button btn-blue"><h3>Preview URL</h3></div></a>
+    <a href="/campaigns"><div class="cta-button btn-blue"><h3>Go to campaigns</h3></div></a>
 
   </div>
 </div>


### PR DESCRIPTION
Make "preview url" & "go to campaigns" link clickable in areas within the button but outside of the text