### PR TITLE
Pull API routes out from main routes and make them RESTful.

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+[*]
+indent_style = space
+end_of_line = lf
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.md]
+max_line_length = 0
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 npm-debug.log
-secrets.js
+secrets*.js
 .github-todos
 .vscode

--- a/app/middleware/campaign.js
+++ b/app/middleware/campaign.js
@@ -7,8 +7,7 @@ var campaignController = {};
 
 // Find campaign by ID: uses shortid to find a specific campaign
 campaignController.findCampaignById = function (shortid) {
-    var findStr = {_id: shortid};
-    campaign = Campaign.find(findStr);
+    var campaign = Campaign.findById(shortid);
     return campaign;
 }
 

--- a/app/middleware/event.js
+++ b/app/middleware/event.js
@@ -17,7 +17,7 @@ eventController.logEvent = function (request, response) {
             campaign: request.body.campaign
         },
         user_agent: {
-            mobile: parsedRequest.isMobile, 
+            mobile: parsedRequest.isMobile,
             browser: {
                 name: parsedRequest.ua.family,
                 version: parsedRequest.ua.toVersionString()
@@ -57,7 +57,7 @@ eventController.createJsonObject = function(dbResult){
 eventController.getAnalytics = function(request, response){
     Event.aggregate([
         {$match:
-            {"metadata.campaign":request.params.campaign_id}
+            {"metadata.campaign":request.params.campaignId}
         },
         {$group:
             {_id:"$type", count: {$sum:1} }

--- a/app/routes/analytics.js
+++ b/app/routes/analytics.js
@@ -4,10 +4,6 @@ module.exports = function (router) {
 
     router.get('/analytics/:campaign_id', function(request, response){
     	response.render('analytics', {logged_in: request.user != null});
-    })
-
-    router.post('/api/analytics/log', eventController.logEvent);
-
-    router.get('/api/analytics/:campaign_id', eventController.getAnalytics);
+    });
 
 };

--- a/app/routes/api/campaign.js
+++ b/app/routes/api/campaign.js
@@ -1,0 +1,58 @@
+const express = require('express');
+const router = express.Router();
+const campaignController = require('../../middleware/campaign');
+const Campaign = require('../../models/campaign');
+
+// Campaign list
+router.route('/campaigns')
+
+// create new campaign
+.post((request, response) => {
+    if(request.user) {
+        campaignPromise = campaignController.saveCampaign(request);
+        campaignPromise.then(function() {
+            return campaignController.findCampaignByTitleAndUser(request.body.title, request.user.id);
+        })
+        .then(function(result) {
+            response.send(result[0]._id);
+        })
+        .catch(function(err) {console.log(err)});
+    } else {
+        response.status(301).render('unauthorized', {logged_in: false});
+    }
+})
+
+// fetch campaign list for a particular user
+.get((request, response) => {
+    if(request.user) {
+        campaignPromise = campaignController.findCampaignsByUser(request.user.id);
+        campaignPromise.then(function(result) {
+            response.send(result);
+        });
+    } else {
+        response.status(301).render('unauthorized', {logged_in: false});
+    }
+});
+
+// Campaign detail
+router.route('/campaigns/:campaignId')
+
+// fetch episode
+.get((request, response) => {
+    // API campaign call page (available to all visitors)
+    campaignController.findCampaignById(request.params.campaignId)
+        .then(function(campaign) {
+            if (campaign.publish) {
+                response.json(campaign);
+            } else {
+                console.log(`Couldn't load campaign page for ${request.params.campaignId}`);
+                response.status(404).send({});
+            }
+        })
+        .catch(function(err) {
+            console.log(`Couldn't load campaign page for ${request.params.campaignId}`);
+            response.json(err);
+        })
+});
+
+module.exports = router;

--- a/app/routes/api/event.js
+++ b/app/routes/api/event.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const router = express.Router();
+var eventController = require('../../middleware/event.js');
+
+router.route('/events')
+
+.post(eventController.logEvent)
+
+.get(eventController.getAnalytics);
+
+module.exports = router;

--- a/app/routes/api/index.js
+++ b/app/routes/api/index.js
@@ -1,0 +1,9 @@
+const express = require('express');
+const router = express.Router();
+const campaignRoutes = require('./campaign');
+const eventRoutes = require('./event');
+
+router.use('/', campaignRoutes);
+router.use('/', eventRoutes);
+
+module.exports = router;

--- a/app/routes/campaign.js
+++ b/app/routes/campaign.js
@@ -1,5 +1,4 @@
- var mongoose = require("mongoose"),
- 	campaignController = require("../middleware/campaign");
+const campaignController = require('../middleware/campaign');
 
 module.exports = function (router) {
 
@@ -13,35 +12,18 @@ module.exports = function (router) {
         }
     });
 
-    // save new campaign
-    router.post('/campaign/create', (request, response) => {
-        if(request.user) {
-            campaignPromise = campaignController.saveCampaign(request);
-            campaignPromise.then(function() {
-                return campaignController.findCampaignByTitleAndUser(request.body.title, request.user.id);
-            })
-            .then(function(result) {
-                response.send(result[0]._id);
-            })
-            .catch(function(err) {console.log(err)});
-        } else {
-            response.status(301).render('unauthorized', {logged_in: false});
-        }
-    });
-
     // edit campaign page
     router.get('/:shortid/edit', (request, response) => {
         if(request.user) {
-            campaignPromise = campaignController.findCampaignById(request.params.shortid);
-            campaignPromise.then(function(result) {
-                campaign = result[0];
-                console.log(campaign);
-                if(request.user.id==campaign.influencer) {
-                    response.render('create',{campData: campaign, logged_in: true});
-                } else {
-                    response.status(301).render('unauthorized', {logged_in: true});
-                }
-            });
+            campaignController.findCampaignById(request.params.shortid)
+                .then(function(campaign) {
+                    console.log(campaign);
+                    if(request.user.id == campaign.influencer) {
+                        response.render('create',{campData: campaign, logged_in: true});
+                    } else {
+                        response.status(301).render('unauthorized', {logged_in: true});
+                    }
+                });
         } else {
             response.status(301).render('unauthorized', {logged_in: false});
         }
@@ -51,7 +33,7 @@ module.exports = function (router) {
     router.get('/:shortid/delete', (request, response) => {
         if(request.user) {
             campaignPromise = campaignController.deleteCampaign(request.params.shortid,request.user.id);
-            campaignPromise.then( function(result) {
+            campaignPromise.then(function(result) {
                 response.redirect('/campaigns');
             });
         } else {
@@ -62,18 +44,6 @@ module.exports = function (router) {
     // campaign list page
     router.get('/campaigns', (request, response) => {
         response.render('campaigns', {logged_in: request.user != null});
-    });
-
-    // fetch campaign list for a particular user
-    router.get('/campaignList', (request, response) => {
-        if(request.user) {
-            campaignPromise = campaignController.findCampaignsByUser(request.user.id);
-            campaignPromise.then(function(result) {
-                response.send(result);
-            });
-        } else {
-            response.status(301).render('unauthorized', {logged_in: false});
-        }
     });
 
     router.get('/campaign', (request, response) => {
@@ -87,42 +57,28 @@ module.exports = function (router) {
 
     // campaign call page (available to all visitors)
     router.get('/:shortid', (request, response) => {
-        campaignPromise = campaignController.findCampaignById(request.params.shortid);
-        campaignPromise.then( function(result) {
+        campaignController.findCampaignById(request.params.shortid)
+            then(function(campaign) {
 
-            if(result.length > 0 && result[0].publish) {
-                response.render('campaign',{campData: result[0], logged_in: request.user != null});
-            } else {
-                console.log(`Couldn't load campaign page for ${request.params.shortid}`);
-                response.status(404).render('404', {logged_in: request.user != null});
-            }
-        });
-    });
-
-    // API campaign call page (available to all visitors)
-    router.get('/api/campaign/:shortid', (request, response) => {
-        campaignPromise = campaignController.findCampaignById(request.params.shortid);
-        campaignPromise.then( function(result) {
-
-            if(result.length > 0 && result[0].publish) {
-                response.send(result[0]);
-            } else {
-                console.log(`Couldn't load campaign page for ${request.params.shortid}`);
-                response.status(404).send({});
-            }
-        });
+                if (campaign.publish) {
+                    response.render('campaign', {campData: campaign, logged_in: request.user != null});
+                } else {
+                    console.log(`Couldn't load campaign page for ${request.params.shortid}`);
+                    response.status(404).render('404', {logged_in: request.user != null});
+                }
+            });
     });
 
     // campaign thank-you page (available to all visitors after completing call)
     router.get('/:shortid/thank-you', (request, response) => {
-        campaignPromise = campaignController.findCampaignById(request.params.shortid);
-        campaignPromise.then( function(result) {
-            if(result.length > 0) {
-                response.render('thankYou',{campData: result[0], logged_in: request.user != null});
-            } else {
-                console.log(`Couldn't find thank you page for ${request.params.shortid}`);
-                response.status(404).render('404', {logged_in: request.user != null});
-            }
-        });
+        campaignController.findCampaignById(request.params.shortid)
+            .then(function(campaign) {
+                if (campaign) {
+                    response.render('thankYou', {campData: campaign, logged_in: request.user != null});
+                } else {
+                    console.log(`Couldn't find thank you page for ${request.params.shortid}`);
+                    response.status(404).render('404', {logged_in: request.user != null});
+                }
+            });
     });
 };

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -4,6 +4,7 @@ var express = require('express');
 var router = express.Router();
 var campaignController = require("../middleware/campaign");
 var influencerController = require("../middleware/influencer");
+var apiRoutes = require('./api')
 
 router.get('/', function(request, response) {
     if(request.user){
@@ -54,6 +55,8 @@ router.get('/locateLegislator', (request, response) => {
 require('./influencer.js')(router);
 require('./analytics.js')(router);
 require('./campaign.js')(router);
+
+router.use('/api', apiRoutes);
 
 router.use(function timeLog (request, response, next) {
   console.log(`Couldn't load any page`);

--- a/public/js/core.js
+++ b/public/js/core.js
@@ -3,7 +3,11 @@ var helloGov = angular.module('helloGov', ['ngMapAutocomplete', 'ngclipboard']).
         $interpolateProvider.startSymbol('{[{').endSymbol('}]}');
 });
 
-helloGov.controller('visitorController', function ($scope, $http, $window, $location) {
+helloGov.constant('constants', {
+    API_ROOT: '/api'
+});
+
+helloGov.controller('visitorController', function ($scope, $http, $window, $location, constants) {
     var urlSplit = $location.absUrl().split('/');
     $scope.campaign = urlSplit.pop();
     $scope.locResult = '';
@@ -11,7 +15,7 @@ helloGov.controller('visitorController', function ($scope, $http, $window, $loca
     $scope.locDetails = '';
 
     $scope.sendEvent = function(type){
-        $http.post('/api/analytics/log', {type: type, campaign: $scope.campaign});
+        $http.post(`${constants.API_ROOT}/events`, {type: type, campaign: $scope.campaign});
     }
     $scope.sendEvent('visit');
     $scope.update = function() {
@@ -41,9 +45,9 @@ helloGov.controller('visitorController', function ($scope, $http, $window, $loca
     $scope.repNotFoundForm = false;
 });
 
-helloGov.controller('campaignController', function ($scope, $http, $window, $location) {
+helloGov.controller('campaignController', function ($scope, $http, $window, $location, constants) {
     $scope.formData = {};
-    $http.get('/campaignList', $scope.campaigns)
+    $http.get(`${constants.API_ROOT}/campaigns`, $scope.campaigns)
     .then(function(result) {
         $scope.campaigns = result.data;
     })
@@ -60,7 +64,7 @@ helloGov.controller('campaignController', function ($scope, $http, $window, $loc
             $scope.formData.shortid = urlSplit[3];
         }
 
-        $http.post('/campaign/create', $scope.formData)
+        $http.post(`${constants.API_ROOT}/campaigns`, $scope.formData)
             .then(function(result) {
                 console.log(result.data);
                 if(publishFlag) {
@@ -131,11 +135,11 @@ helloGov.controller('userController', function ($scope, $http, $window) {
 
 });
 
-helloGov.controller('analyticsController', function($scope, $http, $location) {
+helloGov.controller('analyticsController', function($scope, $http, $location, constants) {
     var urlSplit = $location.absUrl().split('/');
     $scope.campaignId = urlSplit.pop();
 
-    $http.get(`/api/campaign/${$scope.campaignId}`, $scope.campaign)
+    $http.get(`${constants.API_ROOT}/campaigns/${$scope.campaignId}`, $scope.campaign)
     .then(function(result) {
         console.log(`got analytics data: ${result.data}`);
         $scope.campaign = result.data;
@@ -144,7 +148,7 @@ helloGov.controller('analyticsController', function($scope, $http, $location) {
         console.log(`Error:  ${JSON.stringify(data)}`);
     });
 
-    $http.get(`/api/analytics/${$scope.campaignId}`, $scope.analytics)
+    $http.get(`${constants.API_ROOT}/events?campaignId=${$scope.campaignId}`, $scope.analytics)
     .then(function(result) {
         console.log(`got analytics data: ${result.data}`);
         $scope.analytics = result.data;


### PR DESCRIPTION
Note: This PR is additive from the previous PR. Once that one is merged one of the commits will not show up in this diff. 

For this PR I pulled out the ajax routes into a separate /api routing, because when I did the first ticket it was super confusing to me that the full page routes were intermixed with what was essentially a JSON API. This will also allow us in the future to do specific things with these routes only, like require an API key, or a different caching scheme, or some other various middleware specific to an API that is expected to be used client side. I also made the routes RESTful, which I think is a lot easier to work with client side (and a best practice to follow).

I also started making a change to the way we're interacting with mongoose, but then thought better of going all the way down that road in this one PR so I stopped at the `findCampaignById` function. I'll do a separate PR with some improvements with the other methods if this makes sense to you all.

Let me know if you have questions, and sorry I kind of intermingled a few different changes together. Got a little carried away. :)