### PR TITLE
Switch Google Maps script to HTTPS.

### DIFF
--- a/app/views/layouts/main.hbs
+++ b/app/views/layouts/main.hbs
@@ -18,7 +18,7 @@
     <link href="/build/css/styles.css" rel="stylesheet">
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.1.1/jquery.min.js"></script>
-    <script src="http://maps.googleapis.com/maps/api/js?key=AIzaSyDM2H_5tEaB4OM1Dr2iR893KmwczVNXExs&libraries=places" type="text/javascript"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyDM2H_5tEaB4OM1Dr2iR893KmwczVNXExs&libraries=places" type="text/javascript"></script>
     <script src="/build/js/vendor.bundle.js"></script>
 
     <script>


### PR DESCRIPTION
The address autocomplete doesn't work on staging (and any SSL environment) without the Google Maps JS being loaded over SSL as well (at least in Chrome, and probably other browsers too).