### PR TITLE
allow proxy to a list of marketing site urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ conf/env.js
 
 public/build/**
 !.gitkeep
+.tern-project
+

--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -6,6 +6,7 @@ var campaignController = require('../controllers/campaign');
 var apiRoutes = require('./api');
 var config = require('../../conf/config');
 var squareProxy = require('express-http-proxy');
+var url = require('url');
 
 router.get('/', function(request, response, next) {
     if (request.user) {
@@ -14,6 +15,11 @@ router.get('/', function(request, response, next) {
         var proxyResponse = squareProxy(config.marketing_site_url);
         proxyResponse(request, response, next);
     }
+});
+
+router.get(config.marketing_pages, function(request, response, next) {
+	var proxyResponse = squareProxy(url.resolve(config.marketing_site_url, request.url));
+	proxyResponse(request, response, next);
 });
 
 router.get('/home', (request, response) => {

--- a/conf/config.js
+++ b/conf/config.js
@@ -2,7 +2,8 @@ const secrets = require('./secrets');
 const currentEnv = require('./env');
 
 let config = {
-    marketing_site_url: 'http://hellogov.squarespace.com'
+    marketing_site_url: 'http://hellogov.squarespace.com',
+	marketing_pages: ['/request-beta-access', '/faq']
 };
 
 const getEnvConfig = function() {


### PR DESCRIPTION
Note that until we re-enable the faq and request-beta-access pages on squarespace, we're proxying squarespace 404s. 