### PR TITLE
Remove malicious npm package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5082,16 +5082,16 @@
       }
     },
     "nodemon": {
-      "version": "1.18.6",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.6.tgz",
-      "integrity": "sha512-4pHQNYEZun+IkIC2jCaXEhkZnfA7rQe73i8RkdRyDJls/K+WxR7IpI5uNUsAvQ0zWvYcCDNGD+XVtw2ZG86/uQ==",
+      "version": "1.18.7",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.18.7.tgz",
+      "integrity": "sha512-xuC1V0F5EcEyKQ1VhHYD13owznQbUw29JKvZ8bVH7TmuvVNHvvbp9pLgE4PjTMRJVe0pJ8fGRvwR2nMiosIsPQ==",
       "dev": true,
       "requires": {
         "chokidar": "^2.0.4",
         "debug": "^3.1.0",
         "ignore-by-default": "^1.0.1",
         "minimatch": "^3.0.4",
-        "pstree.remy": "^1.1.0",
+        "pstree.remy": "^1.1.2",
         "semver": "^5.5.0",
         "supports-color": "^5.2.0",
         "touch": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -66,8 +66,7 @@
     "eslint-plugin-node": "^4.2.1",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^2.1.1",
-    "pstree.remy": "^1.1.2",
-    "nodemon": "^1.18.6",
+    "nodemon": "^1.18.7",
     "node-sass-middleware": "^0.11.0",
     "webpack-dev-middleware": "^1.10.1"
   }


### PR DESCRIPTION
This updates us to the latest `nodemon` package, which removes the vulnerability exposed by the `event-stream` package. 