### PR TITLE
add successful callback for password validation

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -62,8 +62,9 @@ User.virtual('fullName').get(function() {
 
 var validatePasswordLength = function(password, cb) {
     if (password.length < 7) {
-        cb('Password must be at least 8 characters long.');
+        return cb('Password must be at least 8 characters long.');
     }
+    return cb();
 };
 
 User.plugin(passportLocalMongoose, { passwordValidator: validatePasswordLength });


### PR DESCRIPTION
# Motivation and context
looks like our password validation in #281 broke sign up, I think it should work now though 👍 

# What I did
- `User.register` was failing silently when POSTing to /api/users
- through trial and error it seems like this silent failure was introduced when we added our custom validation `validatePasswordLength()` to the User model
- calling `cb()` with no error message when validation should pass seems to fix it

I think I will make a PR to passport-local-mongoose to add documentation for this feature as well 😅 